### PR TITLE
8 fix deduplicate bug

### DIFF
--- a/integration_tests/dbt_utils/data/sql/data_deduplicate_expected_trino.csv
+++ b/integration_tests/dbt_utils/data/sql/data_deduplicate_expected_trino.csv
@@ -1,0 +1,2 @@
+user_id,event,version,rn
+1,play,2,1

--- a/integration_tests/dbt_utils/data/sql/data_deduplicate_trino.csv
+++ b/integration_tests/dbt_utils/data/sql/data_deduplicate_trino.csv
@@ -1,0 +1,4 @@
+user_id,event,version
+1,play,1
+1,play,2
+2,pause,1

--- a/integration_tests/dbt_utils/models/sql/schema.yml
+++ b/integration_tests/dbt_utils/models/sql/schema.yml
@@ -1,0 +1,7 @@
+version: 2
+
+models:
+  - name: test_deduplicate_trino
+    tests:
+      - dbt_utils.equality:
+          compare_model: ref('data_deduplicate_expected_trino')

--- a/integration_tests/dbt_utils/models/sql/test_deduplicate_trino.sql
+++ b/integration_tests/dbt_utils/models/sql/test_deduplicate_trino.sql
@@ -1,0 +1,21 @@
+with
+
+source as (
+    select *
+    from {{ ref('data_deduplicate_trino') }}
+    where user_id = 1
+),
+
+deduped as (
+
+    {{
+        dbt_utils.deduplicate(
+            'source',
+            partition_by='user_id',
+            order_by='version desc',
+        ) | indent
+    }}
+
+)
+
+select * from deduped

--- a/macros/dbt_utils/sql/deduplicate.sql
+++ b/macros/dbt_utils/sql/deduplicate.sql
@@ -15,6 +15,6 @@
 
     select
         distinct row_numbered.*
-    from row_numbered where row_numbered.rn <> 1
+    from row_numbered where row_numbered.rn = 1
 
 {%- endmacro -%}


### PR DESCRIPTION
closes #8 

This PR is about:

1. Fixing wrong comparison operator in `trino__deduplicate` macro

2. Adding test case for this macro, as it won’t pass test case implemented in `dbt-utils`.

Initially this PR was also aimed to somehow bypass/workaround issue with missing `natural join` in trino. After trying couple ideas and consultation with Michiel, we agreed that it is probably impossible (or implementation is too complicated to be worth further investigation).
Reason - macro should also work with name of CTE passed as an argument, and then it is needed to extract list of columns from that CTE (to workaround lack of natural join), which is a mentioned obstacle.