### PR TITLE
Upgrade dbt trino utils to v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,14 +23,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: 'true'
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.9.5"
+          python-version: "3.11"
 
       - name: Run dbt-trino tests against ${{ matrix.type }}
         run: make dbt-${{ matrix.type }}-tests

--- a/integration_tests/dbt_utils/dbt_project.yml
+++ b/integration_tests/dbt_utils/dbt_project.yml
@@ -53,6 +53,12 @@ seeds:
   +quote_columns: false
   dbt_utils_integration_tests:
     sql:
+      data_get_single_value:
+        +column_types:
+          date_value: timestamp
+          float_value: double
+          int_value: integer
+
       data_width_bucket:
         +column_types:
           num_buckets: integer

--- a/macros/dbt_utils/cross_db_utils/array_append.sql
+++ b/macros/dbt_utils/cross_db_utils/array_append.sql
@@ -1,3 +1,0 @@
-{% macro trino__array_append(array, new_element) -%}
-    {{ dbt_utils.array_concat(array, dbt_utils.array_construct([new_element])) }}
-{%- endmacro %}

--- a/macros/dbt_utils/cross_db_utils/array_concat.sql
+++ b/macros/dbt_utils/cross_db_utils/array_concat.sql
@@ -1,3 +1,0 @@
-{% macro trino__array_concat(array_1, array_2) -%}
-    concat({{ array_1 }}, {{ array_2 }})
-{%- endmacro %}

--- a/macros/dbt_utils/cross_db_utils/array_construct.sql
+++ b/macros/dbt_utils/cross_db_utils/array_construct.sql
@@ -1,7 +1,0 @@
-{% macro trino__array_construct(inputs, data_type) -%}
-    {%- if not inputs -%}
-    NULL
-    {%- else -%}
-    ARRAY[ {{ inputs|join(' , ') }} ]
-    {%- endif -%}
-{%- endmacro %}

--- a/macros/dbt_utils/cross_db_utils/cast_array_to_string.sql
+++ b/macros/dbt_utils/cross_db_utils/cast_array_to_string.sql
@@ -1,3 +1,0 @@
-{% macro trino__cast_array_to_string(array) %}
-    '['||(select array_join({{ array }}, ',', ''))||']'
-{% endmacro %}

--- a/macros/dbt_utils/cross_db_utils/current_timestamp.sql
+++ b/macros/dbt_utils/cross_db_utils/current_timestamp.sql
@@ -1,3 +1,0 @@
-{% macro trino__current_timestamp() %}
-    current_timestamp
-{% endmacro %}

--- a/macros/dbt_utils/generic_tests/equal_rowcount.sql
+++ b/macros/dbt_utils/generic_tests/equal_rowcount.sql
@@ -1,0 +1,74 @@
+{% macro trino__test_equal_rowcount(model, compare_model, group_by_columns) %}
+
+{#-- Needs to be set at parse time, before we return '' below --#}
+{{ config(fail_calc = 'sum(coalesce(diff_count, 0))') }}
+
+{#-- Prevent querying of db in parsing mode. This works because this macro does not create any new refs. #}
+{%- if not execute -%}
+    {{ return('') }}
+{% endif %}
+
+{% if group_by_columns|length() > 0 %}
+  {% set select_gb_cols = group_by_columns|join(', ') + ', ' %}
+  {% set join_gb_cols %}
+    {% for c in group_by_columns %}
+      and a.{{c}} = b.{{c}}
+    {% endfor %}
+  {% endset %}
+  {% set groupby_gb_cols = 'group by ' + group_by_columns|join(',') %}
+{% endif %}
+
+{#-- We must add a fake join key in case additional grouping variables are not provided --#}
+{#-- Redshift does not allow for dynamically created join conditions (e.g. full join on 1 = 1 --#}
+{#-- The same logic is used in fewer_rows_than. In case of changes, maintain consistent logic --#}
+{% set group_by_columns = ['id_dbtutils_test_equal_rowcount'] + group_by_columns %}
+{#-- Instead of specifying columns names passed to GROUP BY clause, pass columns indexes. --#}
+{#-- This workaround is needed because Trino doesn't support lateral column aliasing--#}
+{% set groupby_gb_cols = dbt_utils.group_by(group_by_columns|length) %}
+
+with a as (
+
+    select
+      {{select_gb_cols}}
+      1 as id_dbtutils_test_equal_rowcount,
+      count(*) as count_a
+    from {{ model }}
+    {{groupby_gb_cols}}
+
+
+),
+b as (
+
+    select
+      {{select_gb_cols}}
+      1 as id_dbtutils_test_equal_rowcount,
+      count(*) as count_b
+    from {{ compare_model }}
+    {{groupby_gb_cols}}
+
+),
+final as (
+
+    select
+
+        {% for c in group_by_columns -%}
+          a.{{c}} as {{c}}_a,
+          b.{{c}} as {{c}}_b,
+        {% endfor %}
+
+        count_a,
+        count_b,
+        abs(count_a - count_b) as diff_count
+
+    from a
+    full join b
+    on
+    a.id_dbtutils_test_equal_rowcount = b.id_dbtutils_test_equal_rowcount
+    {{join_gb_cols}}
+
+
+)
+
+select * from final
+
+{% endmacro %}

--- a/macros/dbt_utils/generic_tests/fewer_rows_than.sql
+++ b/macros/dbt_utils/generic_tests/fewer_rows_than.sql
@@ -1,0 +1,78 @@
+{% macro trino__test_fewer_rows_than(model, compare_model, group_by_columns) %}
+
+{{ config(fail_calc = 'sum(coalesce(row_count_delta, 0))') }}
+
+{% if group_by_columns|length() > 0 %}
+  {% set select_gb_cols = group_by_columns|join(' ,') + ', ' %}
+  {% set join_gb_cols %}
+    {% for c in group_by_columns %}
+      and a.{{c}} = b.{{c}}
+    {% endfor %}
+  {% endset %}
+  {% set groupby_gb_cols = 'group by ' + group_by_columns|join(',') %}
+{% endif %}
+
+{#-- We must add a fake join key in case additional grouping variables are not provided --#}
+{#-- Redshift does not allow for dynamically created join conditions (e.g. full join on 1 = 1 --#}
+{#-- The same logic is used in equal_rowcount. In case of changes, maintain consistent logic --#}
+{% set group_by_columns = ['id_dbtutils_test_fewer_rows_than'] + group_by_columns %}
+{#-- Instead of specifying columns names passed to GROUP BY clause, pass columns indexes. --#}
+{#-- This workaround is needed because Trino doesn't support lateral column aliasing--#}
+{% set groupby_gb_cols = dbt_utils.group_by(group_by_columns|length) %}
+
+
+with a as (
+
+    select
+      {{select_gb_cols}}
+      1 as id_dbtutils_test_fewer_rows_than,
+      count(*) as count_our_model
+    from {{ model }}
+    {{ groupby_gb_cols }}
+
+),
+b as (
+
+    select
+      {{select_gb_cols}}
+      1 as id_dbtutils_test_fewer_rows_than,
+      count(*) as count_comparison_model
+    from {{ compare_model }}
+    {{ groupby_gb_cols }}
+
+),
+counts as (
+
+    select
+
+        {% for c in group_by_columns -%}
+          a.{{c}} as {{c}}_a,
+          b.{{c}} as {{c}}_b,
+        {% endfor %}
+
+        count_our_model,
+        count_comparison_model
+    from a
+    full join b on
+    a.id_dbtutils_test_fewer_rows_than = b.id_dbtutils_test_fewer_rows_than
+    {{ join_gb_cols }}
+
+),
+final as (
+
+    select *,
+        case
+            -- fail the test if we have more rows than the reference model and return the row count delta
+            when count_our_model > count_comparison_model then (count_our_model - count_comparison_model)
+            -- fail the test if they are the same number
+            when count_our_model = count_comparison_model then 1
+            -- pass the test if the delta is positive (i.e. return the number 0)
+            else 0
+    end as row_count_delta
+    from counts
+
+)
+
+select * from final
+
+{% endmacro %}

--- a/macros/dbt_utils/generic_tests/not_null_proportion.sql
+++ b/macros/dbt_utils/generic_tests/not_null_proportion.sql
@@ -1,16 +1,24 @@
-{% macro trino__test_not_null_proportion(model) %}
+{% macro trino__test_not_null_proportion(model, group_by_columns) %}
 
 {% set column_name = kwargs.get('column_name', kwargs.get('arg')) %}
 {% set at_least = kwargs.get('at_least', kwargs.get('arg')) %}
 {% set at_most = kwargs.get('at_most', kwargs.get('arg', 1)) %}
 
+{% if group_by_columns|length() > 0 %}
+  {% set select_gb_cols = group_by_columns|join(' ,') + ', ' %}
+  {% set groupby_gb_cols = 'group by ' + group_by_columns|join(',') %}
+{% endif %}
+
 with validation as (
   select
-    sum(case when {{ column_name }} is null then 0 else 1 end) / cast(count(*) as {{dbt_utils.type_numeric()}}) as not_null_proportion
+    {{select_gb_cols}}
+    sum(case when {{ column_name }} is null then 0 else 1 end) / cast(count(*) as {{dbt.type_numeric()}}) as not_null_proportion
   from {{ model }}
+  {{groupby_gb_cols}}
 ),
 validation_errors as (
   select
+    {{select_gb_cols}}
     not_null_proportion
   from validation
   where not_null_proportion < {{ at_least }} or not_null_proportion > {{ at_most }}

--- a/macros/dbt_utils/sql/date_spine.sql
+++ b/macros/dbt_utils/sql/date_spine.sql
@@ -6,7 +6,7 @@
 date_spine(
     "day",
     "to_date('01/01/2016', 'mm/dd/yyyy')",
-    "dateadd(week, 1, current_date)"
+    "dbt.dateadd(week, 1, current_date)"
 ) #}
 
 
@@ -22,7 +22,7 @@ all_periods as (
 
     select (
         {{
-            dateadd(
+            dbt.dateadd(
                 datepart,
                 "row_number() over (order by 1) - 1",
                 "cast(cast(" ~ start_date ~ " as date) as timestamp)"


### PR DESCRIPTION
closes #10 

Adjust `dbt-trino-utils` to [dbt utils v1.0](https://docs.getdbt.com/guides/migration/versions/upgrading-to-dbt-utils-v1.0)