### PR TITLE
Improved support for dbt_date

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ that:
 
 This package provides "shims" for:
 - [dbt_utils](https://github.com/dbt-labs/dbt-utils) (partial)
+- [dbt_date](https://github.com/calogica/dbt-date) (partial)
 
 
 ## Usage
@@ -31,6 +32,8 @@ To make use of these trino adaptations in your dbt project, you must do two thin
     dispatch:
       - macro_namespace: dbt_utils
         search_order: ['trino_utils', 'dbt_utils']
+      - macro_namespace: dbt_date
+        search_order: ['dbt_trino_date', 'dbt_date']
     ```
 Check [dbt Hub](https://hub.getdbt.com) for the latest installation 
 instructions, or [read the docs](https://docs.getdbt.com/docs/package-management) 

--- a/macros/dbt_date/convert_timezone.sql
+++ b/macros/dbt_date/convert_timezone.sql
@@ -1,0 +1,3 @@
+{%- macro trino__convert_timezone(column, target_tz, source_tz=None) -%}
+{{ column }} at time zone '{{ target_tz }}'
+{%- endmacro -%}


### PR DESCRIPTION
`dbt_date` needs to know how to convert a time zone. trino does that using `{{ column }} at time zone '{{ target_tz }}'`