### PR TITLE
Improved support for metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ To make use of these trino adaptations in your dbt project, you must do two thin
     dispatch:
       - macro_namespace: dbt_utils
         search_order: ['trino_utils', 'dbt_utils']
+      - macro_namespace: metrics
+        search_order: ['dbt_trino_metrics', 'metrics']
     ```
 Check [dbt Hub](https://hub.getdbt.com) for the latest installation 
 instructions, or [read the docs](https://docs.getdbt.com/docs/package-management) 

--- a/macros/dbt_metrics/gen_calendar_join.sql
+++ b/macros/dbt_metrics/gen_calendar_join.sql
@@ -1,0 +1,9 @@
+{% macro trino__gen_calendar_join(group_values) %}
+        left join calendar
+        {%- if group_values.window is not none %}
+            on cast(base_model.{{group_values.timestamp}} as date) > date_add('{{group_values.window.period}}', -{{group_values.window.count}}, calendar.date_day)
+            and cast(base_model.{{group_values.timestamp}} as date) <= calendar.date_day
+        {%- else %}
+            on cast(base_model.{{group_values.timestamp}} as date) = calendar.date_day
+        {% endif -%}
+{% endmacro %}


### PR DESCRIPTION
`dbt_metrics` uses some dateadd functionality that looks like this in trino: `date_add('day', -5, calendar.date_day)`
See https://trino.io/docs/current/functions/datetime.html#date_add