### PR TITLE
Support Trino Shim trino__regexp_inst for dbt-expectations

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "dbt-date"]
 	path = dbt-date
 	url = https://github.com/calogica/dbt-date.git
+[submodule "dbt-expectations"]
+	path = dbt-expectations
+	url = git@github.com:calogica/dbt-expectations.git

--- a/integration_tests/dbt_expectations/dbt_project.yml
+++ b/integration_tests/dbt_expectations/dbt_project.yml
@@ -1,0 +1,39 @@
+name: 'trino_utils_dbt_expectations_integration_tests'
+version: '1.0'
+
+profile: 'integration_tests'
+
+config-version: 2
+
+model-paths: ["models"]
+analysis-paths: ["analysis"]
+test-paths: ["tests"]
+seed-paths: ["data"]
+macro-paths: ["macros"]
+
+target-path: "target"  # directory which will store compiled SQL files
+clean-targets:         # directories to be removed by `dbt clean`
+    - "target"
+    - "dbt_modules"
+    - "dbt_packages"
+
+dispatch:
+  - macro_namespace: dbt_utils
+    search_order:
+      [
+        "trino_utils_dbt_expectations_integration_tests",
+        "trino_utils",
+        "dbt",
+        "dbt_utils",
+      ]
+  - macro_namespace: dbt_expectations
+    search_order:
+      [
+        "trino_utils_dbt_expectations_integration_tests",
+        "trino_utils",
+        "dbt",
+        "dbt_expectations",
+      ]
+
+vars:
+  "dbt_date:time_zone": "Pacific Standard Time"

--- a/integration_tests/dbt_expectations/packages.yml
+++ b/integration_tests/dbt_expectations/packages.yml
@@ -1,0 +1,5 @@
+
+packages:
+  - local: ../../
+  - local: ../../dbt-expectations
+  - local: ../../dbt-expectations/integration_tests

--- a/macros/dbt_expectations/regex/regexp_instr.sql
+++ b/macros/dbt_expectations/regex/regexp_instr.sql
@@ -1,0 +1,4 @@
+
+{% macro trino__regexp_instr(source_value, regexp, position, occurrence, is_raw) %}
+regexp_position({{ source_value }}, '{{ regexp }}', {{ position }}, {{ occurrence }})
+{% endmacro %}

--- a/macros/dbt_expectations/regex/regexp_instr.sql
+++ b/macros/dbt_expectations/regex/regexp_instr.sql
@@ -1,4 +1,5 @@
 
-{% macro trino__regexp_instr(source_value, regexp, position, occurrence, is_raw) %}
+{% macro trino__regexp_instr(source_value, regexp, position, occurrence, is_raw, flags) %}
 regexp_position({{ source_value }}, '{{ regexp }}', {{ position }}, {{ occurrence }})
 {% endmacro %}
+


### PR DESCRIPTION
https://github.com/starburstdata/dbt-trino-utils/issues/21

Hi, I need help and definitely guidance for the integration test part. 

Will be thankful for any help to set up the integration tests..

I think we should support dbt-expectations packages and shims for them. since they are like the main tests provider for dbt.
